### PR TITLE
Add unavailable attribute for iOS App Extension

### DIFF
--- a/Sources/DebugMenu/DebugMenu.swift
+++ b/Sources/DebugMenu/DebugMenu.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@available(iOSApplicationExtension, unavailable)
 public struct DebugMenu {
     public static func install(windowScene: UIWindowScene? = nil, items: [DebugMenuPresentable], complications: [ComplicationPresentable], options: [Options] = []) {
         InAppDebuggerWindow.install(windowScene: windowScene, debuggerItems: items, complications: complications, options: options)

--- a/Sources/DebugMenu/Extensions/UIApplication+.swift
+++ b/Sources/DebugMenu/Extensions/UIApplication+.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+@available(iOSApplicationExtension, unavailable)
 extension UIApplication {
     func findKeyWindow() -> UIWindow? {
         (connectedScenes

--- a/Sources/DebugMenu/SwiftUI/DebugMenuModifier.swift
+++ b/Sources/DebugMenu/SwiftUI/DebugMenuModifier.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 
+@available(iOSApplicationExtension, unavailable)
 struct DebugMenuModifier: ViewModifier {
     internal init(debuggerItems: [DebugMenuPresentable], complications: [ComplicationPresentable], options: [Options]) {
         self.debuggerItems = debuggerItems
@@ -28,6 +29,7 @@ struct DebugMenuModifier: ViewModifier {
     }
 }
 
+@available(iOSApplicationExtension, unavailable)
 public extension View {
     @ViewBuilder
     func debugMenu(debuggerItems: [DebugMenuPresentable], complications: [ComplicationPresentable], options: [Options] = [], enabled: Bool = true) -> some View {

--- a/Sources/DebugMenu/View/InAppDebuggerWindow.swift
+++ b/Sources/DebugMenu/View/InAppDebuggerWindow.swift
@@ -10,6 +10,7 @@ import Combine
 
 protocol TouchThrowing {}
 
+@available(iOSApplicationExtension, unavailable)
 public class InAppDebuggerWindow: UIWindow {
     internal static var shared: InAppDebuggerWindow!
     
@@ -24,7 +25,7 @@ public class InAppDebuggerWindow: UIWindow {
     internal override init(frame: CGRect) {
         super.init(frame: frame)
     }
-    
+
     private static func install(_ factory: (() -> InAppDebuggerWindow), debuggerItems: [DebugMenuPresentable], complications: [ComplicationPresentable], options: [Options]) {
         let keyWindow = UIApplication.shared.findKeyWindow()
         shared = factory()


### PR DESCRIPTION
As described below, from Xcode 13.3 beta, Swift packages no longer emits warnings about App Extension.

> Linking Swift packages from application extension targets or watchOS applications no longer emits unresolvable warnings about linking to libraries not safe for use in application extensions. This means that code referencing APIs annotated as unavailable for use in app extensions must now themselves be annotated as unavailable for use in application extensions, in order to allow that code to be used in both apps and app extensions. (66928265)

https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes

This PR follow this change and add unavailable attributes for whole library.