### PR TITLE
Customize launch icon initial position

### DIFF
--- a/Example/UIKitExample/SceneDelegate.swift
+++ b/Example/UIKitExample/SceneDelegate.swift
@@ -59,7 +59,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             ThermalStateDashboardItem(),
             CustomDashboardItem(),
             IntervalDashboardItem(title: "Calc", name: "dev.noppe.calc"),
-        ], options: [.showsWidgetOnLaunch])
+        ], options: [.showsWidgetOnLaunch, .launchIcon(.init(initialPosition: .topTrailing))])
         #endif
     }
 

--- a/Sources/DebugMenu/Entity/Options.swift
+++ b/Sources/DebugMenu/Entity/Options.swift
@@ -11,7 +11,22 @@ import UIKit
 public enum Options {
     case showsWidgetOnLaunch
     case showsRecentItems
-    case launchIcon(UIImage)
+    case launchIcon(LaunchIcon)
+
+    public struct LaunchIcon {
+        public typealias Position = FloatingItemGestureRecognizer.Edge
+
+        let image: UIImage?
+        let initialPosition: Position
+
+        public init(
+            image: UIImage? = nil,
+            initialPosition: Position = .bottomTrailing
+        ) {
+            self.image = image
+            self.initialPosition = initialPosition
+        }
+    }
 
     public static var `default`: [Options] = [.showsRecentItems]
 

--- a/Sources/DebugMenu/Extensions/FloatingItemGestureRecognizer.swift
+++ b/Sources/DebugMenu/Extensions/FloatingItemGestureRecognizer.swift
@@ -29,7 +29,7 @@ public class FloatingItemGestureRecognizer: UIPanGestureRecognizer {
         self.removeTarget(self, action: #selector(pan(_:)))
     }
 
-    public func moveInitialPosition(_ edge: Edge = .bottomTrailing) {
+    public func moveInitialPosition(_ edge: Edge) {
         DispatchQueue.main.async { [weak self] in
             self?.view?.center = self?.cornerPositions()[edge] ?? .zero
             UIView.animate(

--- a/Sources/DebugMenu/View/FloatingViewController.swift
+++ b/Sources/DebugMenu/View/FloatingViewController.swift
@@ -57,7 +57,7 @@ internal class FloatingViewController: UIViewController {
         bug: do {
             let gesture = FloatingItemGestureRecognizer(groundView: self.view)
             launchView.addGestureRecognizer(gesture)
-            gesture.moveInitialPosition()
+            gesture.moveInitialPosition(.bottomTrailing)
 
             let longPress = UILongPressGestureRecognizer()
             longPress.publisher(for: \.state).filter({ $0 == .began })

--- a/Sources/DebugMenu/View/FloatingViewController.swift
+++ b/Sources/DebugMenu/View/FloatingViewController.swift
@@ -28,8 +28,8 @@ internal class FloatingViewController: UIViewController {
         launchView = .init(
             image:
                 options.compactMap { option -> UIImage? in
-                    if case .launchIcon(let image) = option {
-                        return image
+                    if case .launchIcon(let launchIcon) = option {
+                        return launchIcon.image
                     }
                     return nil
                 }
@@ -57,7 +57,17 @@ internal class FloatingViewController: UIViewController {
         bug: do {
             let gesture = FloatingItemGestureRecognizer(groundView: self.view)
             launchView.addGestureRecognizer(gesture)
-            gesture.moveInitialPosition(.bottomTrailing)
+
+            let initialPosition = options
+                .compactMap { option -> Options.LaunchIcon.Position? in
+                    if case .launchIcon(let launchIcon) = option {
+                        return launchIcon.initialPosition
+                    }
+                    return nil
+                }
+                .first ?? .bottomTrailing
+
+            gesture.moveInitialPosition(initialPosition)
 
             let longPress = UILongPressGestureRecognizer()
             longPress.publisher(for: \.state).filter({ $0 == .began })


### PR DESCRIPTION
This PR enables to customize the "bug" icon's initial position by passing `.launchIcon(LaunchIcon)` option.

<img width="320" src="https://user-images.githubusercontent.com/6007952/138114925-cb3aaa46-6f46-4ddc-b879-ec9432155a95.png" />