### PR TITLE
Fix crash / runtime warning on ViewControllerDebugItem

### DIFF
--- a/Sources/DebugMenu/Plugin/DebugMenu/ViewControllerDebugItem.swift
+++ b/Sources/DebugMenu/Plugin/DebugMenu/ViewControllerDebugItem.swift
@@ -9,11 +9,11 @@ public struct ViewControllerDebugItem<T: UIViewController>: DebugItem {
     public init(
         title: String? = nil,
         presentationMode: PresentationMode = .push,
-        builder: @escaping ((T.Type) -> T) = { $0.init() }
+        builder: @escaping @MainActor (T.Type) -> T = { $0.init() }
     ) {
         debugItemTitle = title ?? String(describing: T.self)
         action = .didSelect { controller in
-            let viewController = builder(T.self)
+            let viewController = await builder(T.self)
             switch presentationMode {
             case .present:
                 await controller.present(viewController, animated: true)


### PR DESCRIPTION
Close #33 

To fix this issue, I thought that there is an option making `operation` closure of `DebugItemAction.didSelect` a MainActor since `operation` may process `UIViewController` in some way. But instead, I chose a simpler and less impactful solution by making the `builder` closure of `ViewControllerDebugItem` a MainActor.